### PR TITLE
fix kubectl-completion bug

### DIFF
--- a/provision/master_init.sh
+++ b/provision/master_init.sh
@@ -16,6 +16,8 @@ sed -i 's/192.168.0.0\/16/172.16.0.0\/16/' calico.yaml
 kubectl apply -f rbac-kdd.yaml
 kubectl apply -f calico.yaml
 kubectl get node
+# Ensure using latest bash-completion
+sudo apt install bash-completion -y -f
 echo 'source <(kubectl completion bash)' >>~/.bashrc
 echo 'alias k=kubectl' >>~/.bashrc
 echo 'complete -F __start_kubectl k' >>~/.bashrc


### PR DESCRIPTION
Error when using TAB-completion in an kubectl command, e.g. `kubectl descr[TAB]`.
Error:
`-bash: _get_comp_words_by_ref: command not found`

Vagrant box: 
bento/ubuntu-18.04        (virtualbox, 202002.04.0)

There seems to be an old version of `bash-completion` installed. Updating the package gives a conflict, so `-f` is needed to enforce latest version.

Fix:
`sudo apt install bash-completion -y -f`
